### PR TITLE
Panic occurs in retry when the response is nil

### DIFF
--- a/middleware/retry.go
+++ b/middleware/retry.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 )
 
-// RetryOnStatusRange is a Do func middleware that will retry based on status codes
+// RetryOnStatusCodes is a Do func middleware that will retry based on status codes
 func RetryOnStatusCodes(retry uint, statusCodes ...StatusCodeRange) api.Middleware {
 	// return the middleware func
 	return func(next api.Dofn) api.Dofn {
@@ -13,10 +13,11 @@ func RetryOnStatusCodes(retry uint, statusCodes ...StatusCodeRange) api.Middlewa
 		// return the Do func
 		return func(req *http.Request) (*http.Response, error) {
 
+			// If there is an error, resp can be nil
 			resp, err := next(req)
 
 			retryCount := uint(0)
-			for retryCount < retry && InRanges(resp.StatusCode, statusCodes) {
+			for retryCount < retry && (resp == nil || InRanges(resp.StatusCode, statusCodes)) {
 				retryCount++
 				resp, err = next(req)
 				if err != nil {

--- a/middleware/retry_test.go
+++ b/middleware/retry_test.go
@@ -1,0 +1,51 @@
+package middleware_test
+
+import (
+	"errors"
+	"go-api/middleware"
+	"net/http"
+	"testing"
+)
+
+const retries = 3
+
+func TestRetryNilResponse(t *testing.T) {
+	m := middleware.RetryOnStatusCodes(retries, middleware.StatusCodeRange{Low: 500, High: 599})
+	tryCount := 0
+	m(func(req *http.Request) (*http.Response, error) {
+		tryCount++
+		return nil, errors.New("TestRetryNilResponse error")
+	})(nil)
+	if tryCount != 2 {
+		t.Errorf("expected %d retries, instead got %d", 2, tryCount)
+	}
+}
+
+func TestRetry(t *testing.T) {
+	m := middleware.RetryOnStatusCodes(retries, middleware.StatusCodeRange{Low: 500, High: 599})
+	tryCount := 0
+	m(func(req *http.Request) (*http.Response, error) {
+		tryCount++
+		return &http.Response{
+			StatusCode: 500,
+		}, nil
+	})(nil)
+
+	if tryCount != retries+1 {
+		t.Errorf("expected %d retries, instead got %d", retries+1, tryCount)
+	}
+}
+
+func TestNoRetry(t *testing.T) {
+	m := middleware.RetryOnStatusCodes(retries, middleware.StatusCodeRange{Low: 500, High: 599})
+	tryCount := 0
+	m(func(req *http.Request) (*http.Response, error) {
+		tryCount++
+		return &http.Response{
+			StatusCode: 200,
+		}, nil
+	})(nil)
+	if tryCount != 1 {
+		t.Errorf("expected %d retry, instead got %d", 1, tryCount)
+	}
+}


### PR DESCRIPTION
Sometimes the resp is nil, retry on nil resp or specified status code range.